### PR TITLE
hotfix: emailInput이 아니면 폼에 email 보내지 말기

### DIFF
--- a/src/components/organisms/Home/FormSection.tsx
+++ b/src/components/organisms/Home/FormSection.tsx
@@ -39,7 +39,7 @@ const FormSection = () => {
     const fetchData = {
       comment,
       phone,
-      email: `${id}@${domain}`,
+      email: isEmailInput ? `${id}@${domain}` : '',
       surveyType: 'DEVTI',
       testType: data?.testType ?? '',
     };


### PR DESCRIPTION
## 내용

이메일이 아닌 핸드폰번호로 신청했을때에도 이메일이 전송되는 버그 수정
https://lubycon-hub.slack.com/archives/C01SQ32DB19/p1620699217323100

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

## 특별히 봐줬으면 하는 부분

<!-- 셀프 코멘트도 달아주세요! -->

## 참고 사항

<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
